### PR TITLE
Change URL from http to https

### DIFF
--- a/{{cookiecutter.project_name}}/CHANGELOG.rst
+++ b/{{cookiecutter.project_name}}/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 All notable changes to this project will be documented in this file.
 
 This project adheres to `Semantic Versioning
-<http://semver.org/spec/v2.0.0.html>`_.
+<https://semver.org/spec/v2.0.0.html>`_.
 
 {{ cookiecutter.project_version }} (unreleased)
 ------------------


### PR DESCRIPTION
I know it's nitpicky, but I have a warning when I lintcheck the documentation:

```bash
$ sphinx-build -W -b linkcheck docs docs/_build/linkcheck                                                                                                                                                               
(line    6) redirect  http://semver.org/spec/v2.0.0.html - permanently to https://semver.org/spec/v2.0.0.html
```